### PR TITLE
[Fix] CSS Nav on Safari

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -1,6 +1,6 @@
 <template>
   <nav
-    class="dragging p-2 relative bg-white z-10 flex border-b border-gray-200"
+    class="dragging p-2 relative bg-white z-10 flex border-b border-gray-200 flex-1-0"
     :class="$route.path !== '/' ? 'md:hidden' : ''"
   >
     <!-- In Collections -->
@@ -48,3 +48,9 @@ import { getSearchResults } from '../store'
 
 export default defineComponent(() => getSearchResults())
 </script>
+
+<style>
+.flex-1-0 {
+  flex: 1 0 auto;
+}
+</style>


### PR DESCRIPTION
# Description

I have accessed icones from Safari and seen the glitch of flex on top nav.

![image](https://user-images.githubusercontent.com/6861191/87969133-c2a5ea00-caeb-11ea-87ba-0e629521125d.png)

# Scope of work

I have added flex value as class, `flex-1-0`, to nav.

Not sure that it would be the best practice, please give me an advice. 😁

-----

If you have any feedback or suggestion, do not hesitate to tell me.
