### PR TITLE
chore: changes for vscode extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@iconify/iconify": "^2.0.0-rc.1",
     "@vueuse/core": "^4.0.0-beta.15",
+    "copy-text-to-clipboard": "afzalsayed96/copy-text-to-clipboard",
     "dexie": "^3.0.2",
     "file-saver": "^2.0.2",
     "fuse.js": "^6.4.1",

--- a/src/App.vue
+++ b/src/App.vue
@@ -23,3 +23,26 @@ export default defineComponent({
   },
 })
 </script>
+<style >
+  * {
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+    -ms-overflow-style: -ms-autohiding-scrollbar;
+    scrollbar-width: 6px;
+    scrollbar-color: rgba(0,0,0,.2);
+  }
+
+  ::-webkit-scrollbar {
+    height: 6px;
+    width: 6px;
+  }
+
+  ::-webkit-scrollbar-track-piece {
+    background: rgba(9,30,66,.08);
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: rgba(128,128,128,0.4);
+    border-radius: 3px;
+  }
+</style>

--- a/src/App.vue
+++ b/src/App.vue
@@ -24,25 +24,30 @@ export default defineComponent({
 })
 </script>
 <style >
-  * {
-    overscroll-behavior: contain;
-    -webkit-overflow-scrolling: touch;
-    -ms-overflow-style: -ms-autohiding-scrollbar;
-    scrollbar-width: 6px;
-    scrollbar-color: rgba(0,0,0,.2);
-  }
+* {
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
+  scrollbar-width: 6px;
+  scrollbar-color: rgba(0, 0, 0, 0.2);
+}
 
-  ::-webkit-scrollbar {
-    height: 6px;
-    width: 6px;
-  }
+::-webkit-scrollbar {
+  height: 6px;
+  width: 6px;
+}
 
-  ::-webkit-scrollbar-track-piece {
-    background: rgba(9,30,66,.08);
-  }
+::-webkit-scrollbar-track-piece {
+  background: rgba(9, 30, 66, 0.08);
+}
 
-  ::-webkit-scrollbar-thumb {
-    background: rgba(128,128,128,0.4);
-    border-radius: 3px;
-  }
+::-webkit-scrollbar-thumb {
+  background: rgba(128, 128, 128, 0.4);
+  border-radius: 3px;
+}
+
+::-webkit-scrollbar-thumb:active {
+  background: rgba(128, 128, 128, 0.8);
+  border-radius: 3px;
+}
 </style>

--- a/src/components/IconDetail.vue
+++ b/src/components/IconDetail.vue
@@ -103,10 +103,18 @@
           <div class="my-1 text-gray-500 text-sm">
             Download
           </div>
-          <button class="btn small mr-1 mb-1 opacity-75" @click="download('svg')">SVG</button>
-          <button class="btn small mr-1 mb-1 opacity-75" @click="download('vue')">Vue</button>
-          <button class="btn small mr-1 mb-1 opacity-75" @click="download('jsx')">React</button>
-          <button class="btn small mr-1 mb-1 opacity-75" @click="download('tsx')">React<sup class="opacity-50 -mr-1">TS</sup></button>
+          <button class="btn small mr-1 mb-1 opacity-75" @click="download('svg')">
+            SVG
+          </button>
+          <button class="btn small mr-1 mb-1 opacity-75" @click="download('vue')">
+            Vue
+          </button>
+          <button class="btn small mr-1 mb-1 opacity-75" @click="download('jsx')">
+            React
+          </button>
+          <button class="btn small mr-1 mb-1 opacity-75" @click="download('tsx')">
+            React<sup class="opacity-50 -mr-1">TS</sup>
+          </button>
         </div>
       </div>
     </div>
@@ -118,6 +126,7 @@
 </template>
 
 <script setup="props, {emit}" lang='ts'>
+import copyText from 'copy-text-to-clipboard'
 import FileSaver from 'file-saver'
 import { ref, computed } from 'vue'
 import { getIconSnippet, toComponentName } from '../utils/icons'
@@ -138,8 +147,7 @@ export const copy = async(type: string) => {
   if (!text)
     return
 
-  await navigator.clipboard.writeText(text)
-  copied.value = true
+  copied.value = copyText(text)
   setTimeout(() => {
     copied.value = false
   }, 2000)

--- a/src/components/IconDetail.vue
+++ b/src/components/IconDetail.vue
@@ -103,18 +103,10 @@
           <div class="my-1 text-gray-500 text-sm">
             Download
           </div>
-          <button class="btn small mr-1 mb-1 opacity-75" @click="download('svg')">
-            SVG
-          </button>
-          <button class="btn small mr-1 mb-1 opacity-75" @click="download('vue')">
-            Vue
-          </button>
-          <button class="btn small mr-1 mb-1 opacity-75" @click="download('jsx')">
-            React
-          </button>
-          <button class="btn small mr-1 mb-1 opacity-75" @click="download('tsx')">
-            React<sup class="opacity-50 -mr-1">TS</sup>
-          </button>
+          <button class="btn small mr-1 mb-1 opacity-75" @click="download('svg')">SVG</button>
+          <button class="btn small mr-1 mb-1 opacity-75" @click="download('vue')">Vue</button>
+          <button class="btn small mr-1 mb-1 opacity-75" @click="download('jsx')">React</button>
+          <button class="btn small mr-1 mb-1 opacity-75" @click="download('tsx')">React<sup class="opacity-50 -mr-1">TS</sup></button>
         </div>
       </div>
     </div>

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -3,7 +3,7 @@ import { computed, ref } from 'vue'
 import Iconify from '@purge-icons/generated'
 import infoJSON from '../../public/collections-info.json'
 import { favoritedCollections } from '../store'
-import { isElectron } from '../env'
+import { isElectron, staticPath } from '../env'
 import { saveCollection, loadCollection } from '../store/indexedDB'
 
 export interface CollectionInfo {
@@ -85,7 +85,7 @@ export async function downloadAndInstall(id: string) {
   if (installed.value.includes(id))
     return true
 
-  const data = Object.freeze(await fetch(`/collections/${id}-raw.json`).then(r => r.json()))
+  const data = Object.freeze(await fetch(`${staticPath}/collections/${id}-raw.json`).then(r => r.json()))
 
   Iconify.addCollection(data)
   installed.value.push(id)
@@ -102,7 +102,7 @@ export async function getMeta(id: string): Promise<CollectionMeta | null> {
     return meta
 
   meta = Object.freeze(
-    await fetch(`/collections/${id}-meta.json`).then(r => r.json()),
+    await fetch(`${staticPath}/collections/${id}-meta.json`).then(r => r.json()),
   )
 
   if (!meta)
@@ -118,7 +118,7 @@ export async function getFullMeta() {
     return loadedMeta.value
 
   loadedMeta.value = Object.freeze(
-    await fetch('/collections-meta.json').then(r => r.json()),
+    await fetch(`${staticPath}/collections-meta.json`).then(r => r.json()),
   )
 
   return loadedMeta.value

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,1 +1,6 @@
 export const isElectron = location.protocol === 'app:' || (process.env.NODE_ENV === 'development' && navigator.userAgent.includes('Electron'))
+export const isVSCode = location.protocol === 'vscode-webview:'
+// @ts-ignore
+export const basePath = isVSCode ? window.baseURI : '/'
+// @ts-ignore
+export const staticPath = isVSCode ? window.staticURI : '' 

--- a/src/env.ts
+++ b/src/env.ts
@@ -3,4 +3,4 @@ export const isVSCode = location.protocol === 'vscode-webview:'
 // @ts-ignore
 export const basePath = isVSCode ? window.baseURI : '/'
 // @ts-ignore
-export const staticPath = isVSCode ? window.staticURI : '' 
+export const staticPath = isVSCode ? window.staticURI : ''

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,11 +9,12 @@ import './main.postcss'
 
 // import icons data genereted by PurgeIcons
 import '@purge-icons/generated'
+import { basePath } from './env'
 
 const app = createApp(App)
 
 const router = createRouter({
-  history: createWebHistory(),
+  history: createWebHistory(basePath),
   routes,
 })
 


### PR DESCRIPTION
Hi @antfu 

As discussed, I've tried to make changes to the vue app so a single codebase could work for both vscode and browser environments.

I've also opened a PR at https://github.com/afzalsayed96/vscode-icones/pull/1 which introduces loading built assets locally.

**List of changes**
1. Replace `navigator.writeText` with `copy-text-to-clippboard` package
2. Styled default scrollbar in `App.vue` so it looks better inside vscode
3. Introduce a `basePath` and `staticPath` runtime env variable for vscode environment