### PR TITLE
fix: remove overscroll-behavior

### DIFF
--- a/src/main.postcss
+++ b/src/main.postcss
@@ -48,7 +48,6 @@
 
 /* Scrollbar */
 * {
-  overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
   -ms-overflow-style: -ms-autohiding-scrollbar;
   scrollbar-width: 6px;


### PR DESCRIPTION
One last fix before publishing changes to the extension. The `overscroll-behavior` property was preventing scrolling via mouse wheel inside vscode.