### PR TITLE
fix: body padding and color

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <script src="/lib/svg-packer.js" defer></script>
     <script src="/lib/jszip.min.js" defer></script>
   </head>
-  <body class="dragging bg-white dark:bg-dark-100 dark:text-gray-200">
+  <body class="dragging bg-white dark:bg-dark-100 text-gray-900 dark:text-gray-200">
     <div id="app"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>

--- a/src/main.postcss
+++ b/src/main.postcss
@@ -2,6 +2,10 @@
 @import 'tailwindcss/components';
 @import 'tailwindcss/utilities';
 
+body {
+  padding: 0;
+}
+
 .schema-dark {
   background: #222;
 }


### PR DESCRIPTION
Two more tiny styling related changes

1. Add `body { padding: 0; }` rule to override vscode's added padding to the body
2. Add default body text color for light mode which also override vscode default color