### PR TITLE
feat: copy with color

### DIFF
--- a/src/components/IconDetail.vue
+++ b/src/components/IconDetail.vue
@@ -5,6 +5,12 @@
       <ColorPicker v-model:value="previewColor" class="inline-block">
         <Icon class="p-4 text-8xl" :icon="icon" />
       </ColorPicker>
+      <div class="my-4">
+        <label for="copy-color" class="cursor-pointer">
+          <input type="checkbox" id="copy-color" v-model="copyPreviewColor"> 
+          <span class="px-1 text-gray-500 text-sm">Copy with color</span>
+        </label>
+      </div>
     </div>
     <div class="px-6 py-2 mb-2 md:px-2 md:py-4">
       <button
@@ -164,7 +170,7 @@
 import copyText from 'copy-text-to-clipboard'
 import { getIconSnippet, toComponentName } from '../utils/icons'
 import { collections } from '../data'
-import { getTransformedId, inBag, preferredCase, previewColor, selectingMode, showCaseSelect, showHelp, toggleBag } from '../store'
+import { getTransformedId, inBag, preferredCase, previewColor, copyPreviewColor, selectingMode, showCaseSelect, showHelp, toggleBag } from '../store'
 import { Download } from '../utils/pack'
 import { idCases } from '../utils/case'
 
@@ -184,13 +190,14 @@ const copied = ref(false)
 
 const caseSelector = ref<HTMLDivElement>()
 const transformedId = computed(() => getTransformedId(props.icon))
+const color = computed(() => copyPreviewColor.value ? previewColor.value : 'currentColor')
 
 onClickOutside(caseSelector, () => {
   showCaseSelect.value = false
 })
 
 const copy = async(type: string) => {
-  const text = await getIconSnippet(props.icon, type, true)
+  const text = await getIconSnippet(props.icon, type, true, color.value)
   if (!text)
     return
 
@@ -201,7 +208,7 @@ const copy = async(type: string) => {
 }
 
 const download = async(type: string) => {
-  const text = await getIconSnippet(props.icon, type, false)
+  const text = await getIconSnippet(props.icon, type, false, color.value)
   if (!text)
     return
 

--- a/src/store/localstorage.ts
+++ b/src/store/localstorage.ts
@@ -4,6 +4,7 @@ import { idCases } from '../utils/case'
 export const themeColor = useStorage('icones-theme-color', '#329672')
 export const iconSize = useStorage('icones-icon-size', '2xl')
 export const previewColor = useStorage('icones-preview-color', '#888888')
+export const copyPreviewColor = useStorage('icones-copy-preview-color', false)
 export const listType = useStorage('icones-list-type', 'grid')
 export const favoritedCollections = useStorage<string[]>('icones-fav-collections', [])
 export const bags = useStorage<string[]>('icones-bags', [])

--- a/src/utils/icons.ts
+++ b/src/utils/icons.ts
@@ -5,14 +5,14 @@ import { HtmlToJSX } from './htmlToJsx'
 
 const API_ENTRY = 'https://api.iconify.design'
 
-export async function getSvg(icon: string, size = '1em') {
-  return Iconify.renderSVG(icon, { height: size })?.outerHTML
-   || await fetch(`${API_ENTRY}/${icon}.svg?inline=false&height=${size}`).then(r => r.text()) || ''
+export async function getSvg(icon: string, size = '1em', color = 'currentColor') {
+  return Iconify.renderSVG(icon, { height: size })?.outerHTML?.replace('currentColor', color)
+   || await fetch(`${API_ENTRY}/${icon}.svg?inline=false&height=${size}&color=${encodeURIComponent(color)}`).then(r => r.text()) || ''
 }
 
-export async function getSvgSymbol(icon: string, size = '1em') {
-  const svgMarkup = Iconify.renderSVG(icon, { height: size })?.outerHTML
-  || await fetch(`${API_ENTRY}/${icon}.svg?inline=false&height=${size}`).then(r => r.text()) || ''
+export async function getSvgSymbol(icon: string, size = '1em', color = 'currentColor') {
+  const svgMarkup = Iconify.renderSVG(icon, { height: size })?.outerHTML?.replace('currentColor', color)
+  || await fetch(`${API_ENTRY}/${icon}.svg?inline=false&height=${size}&color=${encodeURIComponent(color)}`).then(r => r.text()) || ''
 
   const symbolElem = document.createElement('symbol')
   const node = document.createElement('div') // Create any old element
@@ -86,7 +86,7 @@ export function SvgToSvelte(svg: string) {
   return ClearSvg(svg)
 }
 
-export async function getIconSnippet(icon: string, type: string, snippet = true): Promise<string | undefined> {
+export async function getIconSnippet(icon: string, type: string, snippet = true, color = 'currentColor'): Promise<string | undefined> {
   if (!icon)
     return
 
@@ -94,27 +94,27 @@ export async function getIconSnippet(icon: string, type: string, snippet = true)
     case 'id':
       return getTransformedId(icon)
     case 'url':
-      return `${API_ENTRY}/${icon}.svg`
+      return `${API_ENTRY}/${icon}.svg?color=${encodeURIComponent(color)}`
     case 'html':
-      return `<span class="iconify" data-icon="${icon}" data-inline="false"></span>`
+      return `<span class="iconify" data-icon="${icon}" data-inline="false"${color === 'currentColor' ? '' : ' style="color: '+color+'"'}></span>`
     case 'css':
-      return `background: url('${API_ENTRY}/${icon}.svg') no-repeat center center / contain;`
+      return `background: url('${API_ENTRY}/${icon}.svg?color=${encodeURIComponent(color)}') no-repeat center center / contain;`
     case 'svg':
-      return await getSvg(icon, '32')
+      return await getSvg(icon, '32', color)
     case 'svg-symbol':
-      return await getSvgSymbol(icon, '32')
+      return await getSvgSymbol(icon, '32', color)
     case 'data_url':
-      return `data:image/svg+xml;base64,${Base64.encode(await getSvg(icon))}`
+      return `data:image/svg+xml;base64,${Base64.encode(await getSvg(icon, undefined, color))}`
     case 'pure-jsx':
-      return ClearSvg(await getSvg(icon))
+      return ClearSvg(await getSvg(icon, undefined, color))
     case 'jsx':
-      return SvgToJSX(await getSvg(icon), toComponentName(icon), snippet)
+      return SvgToJSX(await getSvg(icon, undefined, color), toComponentName(icon), snippet)
     case 'tsx':
-      return SvgToTSX(await getSvg(icon), toComponentName(icon), snippet)
+      return SvgToTSX(await getSvg(icon, undefined, color), toComponentName(icon), snippet)
     case 'vue':
-      return SvgToVue(await getSvg(icon), toComponentName(icon))
+      return SvgToVue(await getSvg(icon, undefined, color), toComponentName(icon))
     case 'svelte':
-      return SvgToSvelte(await getSvg(icon))
+      return SvgToSvelte(await getSvg(icon, undefined, color))
   }
 }
 


### PR DESCRIPTION
This add a **copy with color** checkbox that is by default unchecked to keep initial behavior.
When checked, it either use or reproduce the [color props from iconify api](https://github.com/iconify/json-tools.js/blob/master/src/svg.js#L332-L334), so it works with all export types

![image](https://user-images.githubusercontent.com/3911343/151585682-ef892239-f05d-48ce-844c-89aa8d34e612.png)
> url: `https://api.iconify.design/mdi-light:gift.svg?color=%23ff8000`
> css: `background: url('https://api.iconify.design/mdi-light:gift.svg?color=%23ff8000') no-repeat center center / contain;`

only the html export differ from others, using a style instead
> html: `<span class="iconify" data-icon="mdi-light:gift" data-inline="false" style="color: #ff8000"></span>`

close #52