### PR TITLE
fix: select on menu floats over other buttons

### DIFF
--- a/src/components/ActionsMenu.vue
+++ b/src/components/ActionsMenu.vue
@@ -121,7 +121,7 @@ const installed = computed(() => {
       <IconButton :active="true" icon="carbon:overflow-menu-vertical" title="Menu" />
       <select
         v-model="menu"
-        class="absolute dark:bg-dark-100 text-base top-0 right-0 opacity-0"
+        class="absolute w-full dark:bg-dark-100 text-base top-0 right-0 opacity-0"
       >
         <optgroup label="Size">
           <option value="small">


### PR DESCRIPTION
The select element on the nav is too wide causing it to float over the dark mode switch button.

![nav](https://user-images.githubusercontent.com/46376292/161424394-884496d5-789a-4543-adc5-04f5331ebb69.png)
