### PR TITLE
feat: add copying mode

### DIFF
--- a/src/components/ActionsMenu.vue
+++ b/src/components/ActionsMenu.vue
@@ -79,10 +79,10 @@ watch(
         listType.value = 'list'
         return
       case 'select':
-        activeMode.value = 'selecting'
+        activeMode.value = 'select'
         break
       case 'copy':
-        activeMode.value = 'copying'
+        activeMode.value = 'copy'
         break
       case 'download_iconfont':
         packIconFont()
@@ -137,12 +137,12 @@ const installed = computed(() => {
             List
           </option>
         </optgroup>
-        <optgroup label="Actions">
+        <optgroup label="Modes">
           <option value="select">
-            Select multiple
+            Multiple select
           </option>
           <option value="copy">
-            Copy to clipboard
+            Name copying mode
           </option>
         </optgroup>
 

--- a/src/components/ActionsMenu.vue
+++ b/src/components/ActionsMenu.vue
@@ -1,6 +1,6 @@
 <script setup lang='ts'>
 import type { PropType } from 'vue'
-import { iconSize, inProgress, listType, progressMessage, selectingMode } from '../store'
+import { activeMode, iconSize, inProgress, listType, progressMessage } from '../store'
 import { cacheCollection, downloadAndInstall, isInstalled } from '../data'
 import type { CollectionMeta } from '../data'
 import { PackIconFont, PackSvgZip } from '../utils/pack'
@@ -79,7 +79,10 @@ watch(
         listType.value = 'list'
         return
       case 'select':
-        selectingMode.value = !selectingMode.value
+        activeMode.value = 'selecting'
+        break
+      case 'copy':
+        activeMode.value = 'copying'
         break
       case 'download_iconfont':
         packIconFont()
@@ -137,6 +140,9 @@ const installed = computed(() => {
         <optgroup label="Actions">
           <option value="select">
             Select multiple
+          </option>
+          <option value="copy">
+            Copy to clipboard
           </option>
         </optgroup>
 

--- a/src/components/IconDetail.vue
+++ b/src/components/IconDetail.vue
@@ -2,7 +2,7 @@
 import copyText from 'copy-text-to-clipboard'
 import { getIconSnippet, toComponentName } from '../utils/icons'
 import { collections } from '../data'
-import { copyPreviewColor, getTransformedId, inBag, preferredCase, previewColor, selectingMode, showCaseSelect, showHelp, toggleBag } from '../store'
+import { activeMode, copyPreviewColor, getTransformedId, inBag, preferredCase, previewColor, showCaseSelect, showHelp, toggleBag } from '../store'
 import { Download } from '../utils/pack'
 import { idCases } from '../utils/case'
 
@@ -17,8 +17,7 @@ const props = defineProps({
   },
 })
 
-const emit = defineEmits(['close'])
-const copied = ref(false)
+const emit = defineEmits(['close', 'copy'])
 
 const caseSelector = ref<HTMLDivElement>()
 const transformedId = computed(() => getTransformedId(props.icon))
@@ -33,10 +32,7 @@ const copy = async (type: string) => {
   if (!text)
     return
 
-  copied.value = copyText(text)
-  setTimeout(() => {
-    copied.value = false
-  }, 2000)
+  emit('copy', copyText(text))
 }
 
 const download = async (type: string) => {
@@ -51,9 +47,15 @@ const download = async (type: string) => {
 }
 
 const toggleSelectingMode = () => {
-  selectingMode.value = !selectingMode.value
-  if (selectingMode.value)
-    emit('close')
+  switch (activeMode.value) {
+    case 'selecting':
+      activeMode.value = 'normal'
+      break
+    default:
+      activeMode.value = 'selecting'
+      emit('close')
+      break
+  }
 }
 
 const collection = computed(() => {
@@ -141,7 +143,7 @@ const collection = computed(() => {
             inline-block leading-1em border border-gray-200 my-2 mr-2 font-sans pl-2 pr-3 py-1 rounded-full text-sm cursor-pointer hover:bg-gray-50
             dark:border-dark-200 dark:hover:bg-dark-200
           "
-          :class="selectingMode ? 'text-primary' : 'text-gray-500'"
+          :class="activeMode === 'selecting' ? 'text-primary' : 'text-gray-500'"
           @click="toggleSelectingMode"
         >
           <Icon class="inline-block text-lg align-middle" icon="carbon:list-checked" />
@@ -233,9 +235,5 @@ const collection = computed(() => {
         </div>
       </div>
     </div>
-    <Notification :value="copied">
-      <Icon icon="mdi:check" class="inline-block mr-2 font-xl align-middle" />
-      <span class="align-middle">Copied</span>
-    </Notification>
   </div>
 </template>

--- a/src/components/IconDetail.vue
+++ b/src/components/IconDetail.vue
@@ -48,11 +48,11 @@ const download = async (type: string) => {
 
 const toggleSelectingMode = () => {
   switch (activeMode.value) {
-    case 'selecting':
+    case 'select':
       activeMode.value = 'normal'
       break
     default:
-      activeMode.value = 'selecting'
+      activeMode.value = 'select'
       emit('close')
       break
   }
@@ -81,14 +81,13 @@ const collection = computed(() => {
       </button>
       <div class="flex text-gray-700 relative font-mono dark:text-dark-900">
         {{ transformedId }}
-
         <IconButton icon="carbon:copy" class="ml-2" @click="copy('id')" />
         <IconButton icon="carbon:chevron-up" class="ml-2" @click="showCaseSelect = !showCaseSelect" />
         <div class="flex-auto" />
         <div
           v-if="showCaseSelect"
           ref="caseSelector"
-          class="absolute left-0 bottom-1.8em text-sm rounded shadow p-2 bg-white dark:bg-dark-100"
+          class="absolute left-0 bottom-1.8em text-sm rounded shadow p-2 bg-white dark:bg-dark-100 dark:border dark:border-dark-200"
         >
           <div
             v-for="[k, v] of Object.entries(idCases)"
@@ -143,7 +142,7 @@ const collection = computed(() => {
             inline-block leading-1em border border-gray-200 my-2 mr-2 font-sans pl-2 pr-3 py-1 rounded-full text-sm cursor-pointer hover:bg-gray-50
             dark:border-dark-200 dark:hover:bg-dark-200
           "
-          :class="activeMode === 'selecting' ? 'text-primary' : 'text-gray-500'"
+          :class="activeMode === 'select' ? 'text-primary' : 'text-gray-500'"
           @click="toggleSelectingMode"
         >
           <Icon class="inline-block text-lg align-middle" icon="carbon:list-checked" />

--- a/src/components/IconSet.vue
+++ b/src/components/IconSet.vue
@@ -4,6 +4,7 @@ import { useRoute, useRouter } from 'vue-router'
 import { activeMode, bags, getSearchResults, iconSize, isCurrentCollectionLoading, listType, showHelp, toggleBag } from '../store'
 import { isLocalMode } from '../env'
 import { cacheCollection } from '../data'
+import { getIconSnippet } from '../utils/icons'
 
 const { search, icons, category, collection } = getSearchResults()
 const showBag = ref(false)
@@ -32,13 +33,13 @@ const namespace = computed(() => {
     : `${collection.value.id}:`
 })
 
-const onSelect = (icon: string) => {
+const onSelect = async (icon: string) => {
   switch (activeMode.value) {
-    case 'selecting':
+    case 'select':
       toggleBag(icon)
       break
-    case 'copying':
-      onCopy(copyText(icon))
+    case 'copy':
+      onCopy(copyText(await getIconSnippet(icon, 'id', true) || icon))
       break
     default:
       current.value = icon
@@ -221,13 +222,13 @@ onMounted(() => {
           <HelpPage />
         </ModalDialog>
 
-        <!-- Selecting Note -->
+        <!-- Mode -->
         <div
           class="fixed top-0 right-0 pl-4 pr-2 py-1 rounded-l-full bg-primary text-white shadow mt-16 cursor-pointer transition-transform duration-300 ease-in-out"
           :style="activeMode !== 'normal' ? {} : { transform: 'translateX(120%)' }"
           @click="activeMode = 'normal'"
         >
-          {{ activeMode.replace(/^[a-z](?=[a-z]*)/, (i) => i.toUpperCase()) }} Mode
+          {{ activeMode === 'select' ? 'Multiple select' : 'Name copying mode' }}
           <Icon icon="carbon:close" class="inline-block text-xl align-text-bottom" />
         </div>
 

--- a/src/store/localstorage.ts
+++ b/src/store/localstorage.ts
@@ -1,7 +1,7 @@
 import type { IdCase } from '../utils/case'
 import { idCases } from '../utils/case'
 
-export type ActiveMode = 'normal' | 'selecting' | 'copying'
+export type ActiveMode = 'normal' | 'select' | 'copy'
 
 export const themeColor = useStorage('icones-theme-color', '#329672')
 export const iconSize = useStorage('icones-icon-size', '2xl')

--- a/src/store/localstorage.ts
+++ b/src/store/localstorage.ts
@@ -1,6 +1,8 @@
 import type { IdCase } from '../utils/case'
 import { idCases } from '../utils/case'
 
+export type ActiveMode = 'normal' | 'selecting' | 'copying'
+
 export const themeColor = useStorage('icones-theme-color', '#329672')
 export const iconSize = useStorage('icones-icon-size', '2xl')
 export const previewColor = useStorage('icones-preview-color', '#888888')
@@ -8,7 +10,7 @@ export const copyPreviewColor = useStorage('icones-copy-preview-color', false)
 export const listType = useStorage('icones-list-type', 'grid')
 export const favoritedCollections = useStorage<string[]>('icones-fav-collections', [])
 export const bags = useStorage<string[]>('icones-bags', [])
-export const selectingMode = ref(false)
+export const activeMode = useStorage<ActiveMode>('active-mode', 'normal')
 export const preferredCase = useStorage<IdCase>('icones-preferfed-case', 'iconify')
 
 export function getTransformedId(icon: string) {


### PR DESCRIPTION
I found it useful to now support the ability to copy the name of the icon directly in the drawer after clicking the icon.  However, is it possible to support a mode switch? Clicking on the icon will directly copy the icon name.  Because as a developer, a lot of times I just need to find the icon I want and copy its name so I can reference it in my projects.