### PR TITLE
fix: should not convert some attributes to lowercase

### DIFF
--- a/src/utils/htmlToJsx.ts
+++ b/src/utils/htmlToJsx.ts
@@ -1,9 +1,9 @@
 export function HtmlToJSX(html: string) {
   const jsx = html.replace(/([\w-]+)=/g, (i) => {
-    if (i === 'viewBox=')
+    const words = i.split('-')
+    if (words.length === 1)
       return i
-    return i
-      .split('-')
+    return words
       .map((i, idx) =>
         idx === 0
           ? i.toLowerCase()


### PR DESCRIPTION
Such as `EosIconsThreeDotsLoading` icon,  When I copied it as a vue component, its attributes like `attributeName` and `repeatCount` were converted to `attributename` and `repeatcount`. Therefore, causing the animation to fail.