### PR TITLE
fix: transform svg to react jsx correctly

### DIFF
--- a/src/utils/htmlToJsx.ts
+++ b/src/utils/htmlToJsx.ts
@@ -1,4 +1,18 @@
-export function HtmlToJSX(html: string) {
+function transformToReactJSX(jsx: string) {
+  const reactJSX = jsx.replace(/(class|(\w+:\w+))=/g, (i) => {
+    if (i === 'class=')
+      return 'className='
+    return i.split(':')
+      .map((i, idx) =>
+        idx === 0
+          ? i.toLowerCase()
+          : i[0].toUpperCase() + i.slice(1).toLowerCase())
+      .join('')
+  })
+  return reactJSX
+}
+
+export function HtmlToJSX(html: string, reactJSX = false) {
   const jsx = html.replace(/([\w-]+)=/g, (i) => {
     const words = i.split('-')
     if (words.length === 1)
@@ -10,5 +24,5 @@ export function HtmlToJSX(html: string) {
           : i[0].toUpperCase() + i.slice(1).toLowerCase())
       .join('')
   })
-  return jsx
+  return reactJSX ? transformToReactJSX(jsx) : jsx
 }

--- a/src/utils/icons.ts
+++ b/src/utils/icons.ts
@@ -30,7 +30,7 @@ export function toComponentName(icon: string) {
   return icon.split(/:|-|_/).filter(Boolean).map(s => s[0].toUpperCase() + s.slice(1).toLowerCase()).join('')
 }
 
-export function ClearSvg(svgCode: string) {
+export function ClearSvg(svgCode: string, reactJSX?: boolean) {
   const el = document.createElement('div')
   el.innerHTML = svgCode
   const svg = el.getElementsByTagName('svg')[0]
@@ -40,14 +40,14 @@ export function ClearSvg(svgCode: string) {
       continue
     svg.removeAttributeNode(key)
   }
-  return HtmlToJSX(el.innerHTML)
+  return HtmlToJSX(el.innerHTML, reactJSX)
 }
 
 export function SvgToJSX(svg: string, name: string, snippet: boolean) {
   const code = `
 export function ${name}(props) {
   return (
-    ${ClearSvg(svg).replace(/<svg (.*?)>/, '<svg $1 {...props}>')}
+    ${ClearSvg(svg, true).replace(/<svg (.*?)>/, '<svg $1 {...props}>')}
   )
 }`
   if (snippet)
@@ -60,7 +60,7 @@ export function SvgToTSX(svg: string, name: string, snippet: boolean) {
   const code = `
 export function ${name}(props: SVGProps<SVGSVGElement>) {
   return (
-    ${ClearSvg(svg).replace(/<svg (.*?)>/, '<svg $1 {...props}>')}
+    ${ClearSvg(svg, true).replace(/<svg (.*?)>/, '<svg $1 {...props}>')}
   )
 }`
   if (snippet)


### PR DESCRIPTION
There are some differences between react jsx and pure jsx. React jsx doesn't support namespace tags, so when copying it, the attribute `xmlns:xlink` should be transformed to `xmlnsXlink`. Also, `class` should be `className`.