### PR TITLE
feat: add copy for Edge button

### DIFF
--- a/src/components/IconDetail.vue
+++ b/src/components/IconDetail.vue
@@ -180,6 +180,9 @@ const collection = computed(() => {
           <button class="btn small mr-1 mb-1 opacity-75" @click="copy('pure-jsx')">
             JSX
           </button>
+          <button class="btn small mr-1 mb-1 opacity-75" @click="copy('edge')">
+            Edge
+          </button>
         </div>
         <div class="mr-4">
           <div class="my-1 text-gray-500 text-sm">

--- a/src/utils/icons.ts
+++ b/src/utils/icons.ts
@@ -121,6 +121,8 @@ export async function getIconSnippet(icon: string, type: string, snippet = true,
       return SvgToSvelte(await getSvg(icon, undefined, color))
     case 'unplugin':
       return `import ${toComponentName(icon)} from '~icons/${icon.split(':')[0]}/${icon.split(':')[1]}'`
+    case 'edge':
+      return `@svg('${icon}')`
   }
 }
 


### PR DESCRIPTION
Hey ! Thanks for this cool project, I use it every day when I am using UnoCSS and the icons preset.

We recently added support for Iconify in Edge, the templating engine of the AdonisJS framework via this plug in: 
https://github.com/edge-js/edge-iconify

So I just added a little button to get a snippet for Edge !