### PR TITLE
feat: add shortcuts to search and close icon detail

### DIFF
--- a/src/components/IconSet.vue
+++ b/src/components/IconSet.vue
@@ -82,17 +82,17 @@ onMounted(() => {
   })
 })
 
- onKeyStroke('/', (e) => {
-   e.preventDefault()
-   input.value!.focus()
- })
+onKeyStroke('/', (e) => {
+  e.preventDefault()
+  input.value!.focus()
+})
 
- onKeyStroke('Escape', () => {
-   if (current.value !== '') {
-     current.value = ''
-     input.value!.focus()
-   }
- })
+onKeyStroke('Escape', () => {
+  if (current.value !== '') {
+    current.value = ''
+    input.value!.focus()
+  }
+})
 </script>
 
 <template>
@@ -176,14 +176,14 @@ onMounted(() => {
           <Icon icon="carbon:search" class="m-auto flex-none opacity-60" />
           <form action="/collection/all" class="flex-auto" role="search" method="get" @submit.prevent>
             <input
+              ref="input"
               :value="search"
-              @input="e => search = (e.target as HTMLInputElement).value"
               aria-label="Search"
               class="text-base outline-none w-full py-1 px-4 m-0 bg-transparent"
               name="s"
               placeholder="Search..."
-              ref="input"
               autofocus
+              @input="e => search = (e.target as HTMLInputElement).value"
             >
           </form>
 

--- a/src/components/IconSet.vue
+++ b/src/components/IconSet.vue
@@ -1,6 +1,7 @@
 <script setup lang='ts'>
 import copyText from 'copy-text-to-clipboard'
 import { useRoute, useRouter } from 'vue-router'
+import hotkeys from 'hotkeys-js'
 import { activeMode, bags, getSearchResults, iconSize, isCurrentCollectionLoading, listType, showHelp, toggleBag } from '../store'
 import { isLocalMode } from '../env'
 import { cacheCollection } from '../data'
@@ -13,6 +14,7 @@ const copied = ref(false)
 const maxMap = new Map<string, number>()
 const current = ref('')
 const max = ref(isLocalMode ? 500 : 200)
+const input = ref<HTMLInputElement>()
 
 const onCopy = (status: boolean) => {
   copied.value = status
@@ -79,6 +81,19 @@ onMounted(() => {
   watch([search, collection], () => {
     router.replace({ query: { s: search.value } })
   })
+  hotkeys('esc', () => {
+    if (current.value !== '') {
+      current.value = ''
+      input.value!.focus()
+    }
+  })
+  hotkeys('/', (e) => {
+    e.preventDefault()
+    input.value!.focus()
+  })
+})
+onUnmounted(() => {
+  hotkeys.unbind('esc, /')
 })
 </script>
 
@@ -163,11 +178,14 @@ onMounted(() => {
           <Icon icon="carbon:search" class="m-auto flex-none opacity-60" />
           <form action="/collection/all" class="flex-auto" role="search" method="get" @submit.prevent>
             <input
-              v-model="search"
+              :value="search"
+              @input="e => search = (e.target as HTMLInputElement).value"
               aria-label="Search"
               class="text-base outline-none w-full py-1 px-4 m-0 bg-transparent"
               name="s"
               placeholder="Search..."
+              ref="input"
+              autofocus
             >
           </form>
 

--- a/src/components/IconSet.vue
+++ b/src/components/IconSet.vue
@@ -1,7 +1,6 @@
 <script setup lang='ts'>
 import copyText from 'copy-text-to-clipboard'
 import { useRoute, useRouter } from 'vue-router'
-import hotkeys from 'hotkeys-js'
 import { activeMode, bags, getSearchResults, iconSize, isCurrentCollectionLoading, listType, showHelp, toggleBag } from '../store'
 import { isLocalMode } from '../env'
 import { cacheCollection } from '../data'
@@ -81,20 +80,19 @@ onMounted(() => {
   watch([search, collection], () => {
     router.replace({ query: { s: search.value } })
   })
-  hotkeys('esc', () => {
-    if (current.value !== '') {
-      current.value = ''
-      input.value!.focus()
-    }
-  })
-  hotkeys('/', (e) => {
-    e.preventDefault()
-    input.value!.focus()
-  })
 })
-onUnmounted(() => {
-  hotkeys.unbind('esc, /')
-})
+
+ onKeyStroke('/', (e) => {
+   e.preventDefault()
+   input.value!.focus()
+ })
+
+ onKeyStroke('Escape', () => {
+   if (current.value !== '') {
+     current.value = ''
+     input.value!.focus()
+   }
+ })
 </script>
 
 <template>

--- a/src/components/IconSet.vue
+++ b/src/components/IconSet.vue
@@ -177,13 +177,13 @@ onKeyStroke('Escape', () => {
           <form action="/collection/all" class="flex-auto" role="search" method="get" @submit.prevent>
             <input
               ref="input"
-              :value="search"
+              v-model="search"
               aria-label="Search"
               class="text-base outline-none w-full py-1 px-4 m-0 bg-transparent"
               name="s"
               placeholder="Search..."
               autofocus
-              @input="e => search = (e.target as HTMLInputElement).value"
+              autocomplete="off"
             >
           </form>
 

--- a/src/pages/collection/[id].vue
+++ b/src/pages/collection/[id].vue
@@ -26,5 +26,5 @@ onMounted(() => {
       Loading...
     </div>
   </WithNavbar>
-  <IconSet v-else :collection="collection" />
+  <IconSet v-else />
 </template>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -1,4 +1,6 @@
 <script setup lang='ts'>
+import hotkeys from 'hotkeys-js'
+import { useRouter } from 'vue-router'
 import type { PresentType } from '../data'
 import { categories, collections, favoritedCollections, recentCollections } from '../data'
 
@@ -19,6 +21,16 @@ const categorized = computed(() => [
     collections: collections.filter(collection => collection.category === category),
   })),
 ])
+
+onMounted(() =>{
+  const router = useRouter()
+  hotkeys('/', () => {
+    router.replace('/collection/all')
+  })
+})
+onUnmounted(() => {
+  hotkeys.unbind('/')
+})
 </script>
 
 <template>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -1,6 +1,4 @@
 <script setup lang='ts'>
-import hotkeys from 'hotkeys-js'
-import { useRouter } from 'vue-router'
 import type { PresentType } from '../data'
 import { categories, collections, favoritedCollections, recentCollections } from '../data'
 
@@ -22,14 +20,9 @@ const categorized = computed(() => [
   })),
 ])
 
-onMounted(() =>{
-  const router = useRouter()
-  hotkeys('/', () => {
-    router.replace('/collection/all')
-  })
-})
-onUnmounted(() => {
-  hotkeys.unbind('/')
+const router = useRouter()
+onKeyStroke('/', () => {
+  router.replace('/collection/all')
 })
 </script>
 


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

This pull request adds shortcuts to search and close icon detail, for a faster workflow.

- On index page <kbd>/</kbd> goes to all icon search
  - To comply with this change, the search box is now auto focused
- On icon search page <kbd>/</kbd> focuses the search box
- <kbd>Esc</kbd> closes icon detail when opened

There is also a slight tweak in how search box handles input, it now correctly responds inputs via a IME (so one doesn't need to submit the word in order to get search feedback).


https://user-images.githubusercontent.com/44045911/180647546-64de4fee-c76f-4e4d-9b12-dcdc8e4ed377.mov



### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
