### PR TITLE
feat: search and sort categories

### DIFF
--- a/src/components/Drawer.vue
+++ b/src/components/Drawer.vue
@@ -1,6 +1,6 @@
 <script setup lang='ts'>
 import { sortedCollectionsInfo } from '../data'
-import { isFavorited, toggleFavorite } from '../store'
+import { categorySearch, isFavorited, sortAlphabetically, toggleAlphabeticalSort, toggleFavorite } from '../store'
 import { isElectron } from '../env'
 
 const route = useRoute()
@@ -27,6 +27,37 @@ const collections = computed(() => {
         @click="$router.replace('/')"
       >
         <div i-carbon:arrow-left />
+      </button>
+    </div>
+
+    <!-- Searching -->
+    <div class="hidden py-2 md:flex border-b rounded outline-none py-1 px-4 dark:border-dark-200">
+      <Icon icon="carbon:search" class="m-auto flex-none opacity-60" />
+      <form action="/collection/all" class="flex-auto" role="search" method="get" @submit.prevent>
+        <input
+          ref="input"
+          v-model="categorySearch"
+          aria-label="Search"
+          class="text-xs outline-none w-full py-1 px-4 m-0 bg-transparent font-normal"
+          name="s"
+          placeholder="Search category..."
+          autofocus
+          autocomplete="off"
+        >
+      </form>
+
+      <button
+        class="flex items-center transition"
+        :class="{
+          'text-gray-500 hover:text-gray-600': sortAlphabetically,
+          'text-gray-300 hover:text-gray-400': !sortAlphabetically,
+        }"
+        @click="toggleAlphabeticalSort()"
+      >
+        <Icon
+          icon="mdi:sort-alphabetical-ascending"
+          class="m-auto text-lg -mr-1 "
+        />
       </button>
     </div>
 

--- a/src/components/Drawer.vue
+++ b/src/components/Drawer.vue
@@ -1,6 +1,6 @@
 <script setup lang='ts'>
 import { sortedCollectionsInfo } from '../data'
-import { categorySearch, isFavorited, sortAlphabetically, toggleAlphabeticalSort, toggleFavorite } from '../store'
+import { categorySearch, isFavorited, sortAlphabetically, toggleFavorite } from '../store'
 import { isElectron } from '../env'
 
 const route = useRoute()
@@ -52,7 +52,7 @@ const collections = computed(() => {
           'text-gray-500 hover:text-gray-600': sortAlphabetically,
           'text-gray-300 hover:text-gray-400': !sortAlphabetically,
         }"
-        @click="toggleAlphabeticalSort()"
+        @click="sortAlphabetically = !sortAlphabetically"
       >
         <Icon
           icon="mdi:sort-alphabetical-ascending"

--- a/src/components/IconSet.vue
+++ b/src/components/IconSet.vue
@@ -93,6 +93,7 @@ onMounted(() => {
 router.afterEach((to) => {
   if (to.path === '/')
     search.value = ''
+  input?.focus()
 })
 
 onKeyStroke('/', (e) => {

--- a/src/components/IconSet.vue
+++ b/src/components/IconSet.vue
@@ -90,10 +90,17 @@ onMounted(() => {
   })
 })
 
+function focusSearch() {
+  input?.focus()
+}
+
+onMounted(focusSearch)
+watch(router.currentRoute, focusSearch, { immediate: true })
+
 router.afterEach((to) => {
   if (to.path === '/')
     search.value = ''
-  input?.focus()
+  focusSearch()
 })
 
 onKeyStroke('/', (e) => {

--- a/src/components/WithNavbar.vue
+++ b/src/components/WithNavbar.vue
@@ -6,7 +6,7 @@ import { isElectron } from '../env'
   <div class="flex h-screen flex-col overflow-hidden">
     <Navbar v-if="!isElectron" />
     <NavElectron v-if="isElectron" />
-    <div class="flex-auto overflow-overlay">
+    <div class="flex-auto overflow-overlay flex flex-col">
       <slot />
     </div>
   </div>

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -1,6 +1,6 @@
 <script setup lang='ts'>
 import type { PresentType } from '../data'
-import { categorySearch, sortAlphabetically, toggleAlphabeticalSort } from '../store'
+import { categorySearch, sortAlphabetically } from '../store'
 import { categories, favoritedCollections, filteredCollections, recentCollections } from '../data'
 
 const input = ref<HTMLInputElement>()
@@ -60,7 +60,7 @@ onMounted(() => input.value?.focus())
           'opacity-50 hover:opacity-70': sortAlphabetically,
           'opacity-30 hover:opacity-50': !sortAlphabetically,
         }"
-        @click="toggleAlphabeticalSort()"
+        @click="sortAlphabetically = !sortAlphabetically"
       >
         <Icon
           icon="mdi:sort-alphabetical-ascending"

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -1,7 +1,9 @@
 <script setup lang='ts'>
 import type { PresentType } from '../data'
-import { categories, collections, favoritedCollections, recentCollections } from '../data'
+import { categorySearch, sortAlphabetically, toggleAlphabeticalSort } from '../store'
+import { categories, favoritedCollections, filteredCollections, recentCollections } from '../data'
 
+const input = ref<HTMLInputElement>()
 const categorized = computed(() => [
   {
     name: 'Favorites',
@@ -16,14 +18,13 @@ const categorized = computed(() => [
   ...categories.map(category => ({
     name: category,
     type: 'normal' as PresentType,
-    collections: collections.filter(collection => collection.category === category),
+    collections: filteredCollections.value.filter(collection => collection.category === category),
   })),
 ])
 
 const router = useRouter()
-onKeyStroke('/', () => {
-  router.replace('/collection/all')
-})
+onKeyStroke('/', () => router.replace('/collection/all'))
+onMounted(() => input.value?.focus())
 </script>
 
 <template>
@@ -33,8 +34,44 @@ onKeyStroke('/', () => {
         Icônes
       </div>
     </NavPlaceholder>
+
+    <!-- Searching -->
+    <div class="border-b py-3 md:mx-6 mb-2 md:mt-6 flex md:shadow md:rounded outline-none md:py-1 px-4 md:border md:border-transparent dark:border-dark-200">
+      <Icon icon="carbon:search" class="m-auto flex-none opacity-60" />
+      <form action="/collection/all" class="flex-auto" role="search" method="get" @submit.prevent>
+        <input
+          ref="input"
+          v-model="categorySearch"
+          aria-label="Search"
+          class="text-base outline-none w-full py-1 px-4 m-0 bg-transparent"
+          name="s"
+          placeholder="Search category..."
+          autofocus
+          autocomplete="off"
+        >
+      </form>
+
+      <button class="flex items-center opacity-60 hover:opacity-80">
+        <Icon v-if="categorySearch" icon="carbon:close" class="m-auto text-lg -mr-1" @click="categorySearch = ''" />
+      </button>
+      <button
+        class="flex items-center transition ml-4"
+        :class="{
+          'opacity-50 hover:opacity-70': sortAlphabetically,
+          'opacity-30 hover:opacity-50': !sortAlphabetically,
+        }"
+        @click="toggleAlphabeticalSort()"
+      >
+        <Icon
+          icon="mdi:sort-alphabetical-ascending"
+          class="m-auto text-lg -mr-1 "
+        />
+      </button>
+    </div>
+
+    <!-- Category listing -->
     <template v-for="c of categorized" :key="c.name">
-      <div v-if="c.collections.length" px4>
+      <div v-if="(c.collections).length" px4>
         <div px-2 op50 mt6 text-lg>
           {{ c.name }}
         </div>
@@ -45,6 +82,14 @@ onKeyStroke('/', () => {
         />
       </div>
     </template>
+
+    <div
+      v-if="categorized.every(c => !c.collections.length)"
+      class="flex flex-col flex-grow w-full py-6 justify-center items-center"
+    >
+      <Icon icon="ph:x-circle-bold" class="text-4xl mb-2 opacity-20" />
+      <span class="text-lg opacity-60">There is no result corresponding to your search query.</span>
+    </div>
     <Footer />
   </WithNavbar>
 </template>

--- a/src/store/localstorage.ts
+++ b/src/store/localstorage.ts
@@ -15,6 +15,7 @@ export const recentIds = useStorage<string[]>('icones-recent-collections', [])
 export const bags = useStorage<string[]>('icones-bags', [])
 export const activeMode = useStorage<ActiveMode>('active-mode', 'normal')
 export const preferredCase = useStorage<IdCase>('icones-preferfed-case', 'iconify')
+export const sortAlphabetically = useStorage('icones-alpha-sort-collections', false)
 
 export function getTransformedId(icon: string) {
   return idCases[preferredCase.value]?.(icon) || icon

--- a/src/store/search.ts
+++ b/src/store/search.ts
@@ -1,3 +1,2 @@
 export const isSearchOpen = ref(false)
 export const categorySearch = ref('')
-export const [sortAlphabetically, toggleAlphabeticalSort] = useToggle(false)

--- a/src/store/search.ts
+++ b/src/store/search.ts
@@ -1,1 +1,3 @@
 export const isSearchOpen = ref(false)
+export const categorySearch = ref('')
+export const [sortAlphabetically, toggleAlphabeticalSort] = useToggle(false)


### PR DESCRIPTION
### Description

This PR adds a way to search for specific categories, as well as order them alphabetically. These features are on the index page and on the drawer.

I find myself `Ctrl+F`ing for a specific icon set each time I open Icones. While looking if a PR or issue was open, I saw #88, and I thought it was relevant so I also implemented it.

Additionally, I also fixed a few edge cases where the search input wasn't focusing automatically.

### Linked Issues

Closes https://github.com/antfu/icones/issues/88

### Preview



https://user-images.githubusercontent.com/16060559/187660576-627178cf-ca91-490a-8d51-ce4630b41bd5.mp4



