### PR TITLE
fix: use Clipboard API to copy code samples

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "@antfu/utils": "^0.5.2",
     "@vueuse/core": "^9.3.0",
-    "copy-text-to-clipboard": "^3.0.1",
     "dexie": "^3.2.2",
     "file-saver": "^2.0.5",
     "fzf": "^0.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,6 @@ specifiers:
   '@types/fs-extra': ^9.0.13
   '@vitejs/plugin-vue': ^3.1.0
   '@vueuse/core': ^9.3.0
-  copy-text-to-clipboard: ^3.0.1
   cross-env: ^7.0.3
   dayjs: ^1.11.5
   dexie: ^3.2.2
@@ -44,7 +43,6 @@ specifiers:
 dependencies:
   '@antfu/utils': 0.5.2
   '@vueuse/core': 9.3.0_vue@3.2.40
-  copy-text-to-clipboard: 3.0.1
   dexie: 3.2.2
   file-saver: 2.0.5
   fzf: 0.5.1
@@ -1682,6 +1680,7 @@ packages:
 
   /@types/web-bluetooth/0.0.15:
     resolution: {integrity: sha512-w7hEHXnPMEZ+4nGKl/KDRVpxkwYxYExuHOYXyzIzCDzEZ9ZCGMAewulr9IqJu2LR4N37fcnb1XVeuZ09qgOxhA==}
+    dev: false
 
   /@typescript-eslint/eslint-plugin/5.38.1_c7qepppml3d4ahu5cnfwqe6ltq:
     resolution: {integrity: sha512-ky7EFzPhqz3XlhS7vPOoMDaQnQMn+9o5ICR9CPr/6bw8HrFkzhMSxuA3gRfiJVvs7geYrSeawGJjZoZQKCOglQ==}
@@ -2075,6 +2074,7 @@ packages:
     dependencies:
       '@vue/reactivity': 3.2.40
       '@vue/shared': 3.2.40
+    dev: false
 
   /@vue/runtime-dom/3.2.40:
     resolution: {integrity: sha512-AO2HMQ+0s2+MCec8hXAhxMgWhFhOPJ/CyRXnmTJ6XIOnJFLrH5Iq3TNwvVcODGR295jy77I6dWPj+wvFoSYaww==}
@@ -2082,6 +2082,7 @@ packages:
       '@vue/runtime-core': 3.2.40
       '@vue/shared': 3.2.40
       csstype: 2.6.20
+    dev: false
 
   /@vue/server-renderer/3.2.40_vue@3.2.40:
     resolution: {integrity: sha512-gtUcpRwrXOJPJ4qyBpU3EyxQa4EkV8I4f8VrDePcGCPe4O/hd0BPS7v9OgjIQob6Ap8VDz9G+mGTKazE45/95w==}
@@ -2091,6 +2092,7 @@ packages:
       '@vue/compiler-ssr': 3.2.40
       '@vue/shared': 3.2.40
       vue: 3.2.40
+    dev: false
 
   /@vue/shared/3.2.38:
     resolution: {integrity: sha512-dTyhTIRmGXBjxJE+skC8tTWCGLCVc4wQgRRLt8+O9p5ewBAjoBwtCAkLPrtToSr1xltoe3st21Pv953aOZ7alg==}
@@ -2109,9 +2111,11 @@ packages:
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
+    dev: false
 
   /@vueuse/metadata/9.3.0:
     resolution: {integrity: sha512-GnnfjbzIPJIh9ngL9s9oGU1+Hx/h5/KFqTfJykzh/1xjaHkedV9g0MASpdmPZIP+ynNhKAcEfA6g5i8KXwtoMA==}
+    dev: false
 
   /@vueuse/shared/4.11.2_vue@3.2.40:
     resolution: {integrity: sha512-vTbTi6ou7ljH3CkKVoaIaCAoWB5T1ewSogpL6VnO1duMPNuiv7x8K/LunMbnTg4tVyt6QwaiCuEq/kyS6AUBRg==}
@@ -2129,6 +2133,7 @@ packages:
     transitivePeerDependencies:
       - '@vue/composition-api'
       - vue
+    dev: false
 
   /abbrev/1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
@@ -2576,11 +2581,6 @@ packages:
       safe-buffer: 5.1.2
     dev: true
 
-  /copy-text-to-clipboard/3.0.1:
-    resolution: {integrity: sha512-rvVsHrpFcL4F2P8ihsoLdFHmd404+CMg71S756oRSeQgqk51U3kicGdnvfkrxva0xXH92SjGS62B0XIJsbh+9Q==}
-    engines: {node: '>=12'}
-    dev: false
-
   /core-js-compat/3.24.1:
     resolution: {integrity: sha512-XhdNAGeRnTpp8xbD+sR/HFDK9CbeeeqXT6TuofXh3urqEevzkWmLRgrVoykodsw8okqo2pu1BOmuCKrHx63zdw==}
     dependencies:
@@ -2642,6 +2642,7 @@ packages:
 
   /csstype/2.6.20:
     resolution: {integrity: sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==}
+    dev: false
 
   /cubic2quad/1.2.1:
     resolution: {integrity: sha512-wT5Y7mO8abrV16gnssKdmIhIbA9wSkeMzhh27jAguKrV82i24wER0vL5TGhUJ9dbJNDcigoRZ0IAHFEEEI4THQ==}
@@ -6281,6 +6282,7 @@ packages:
         optional: true
     dependencies:
       vue: 3.2.40
+    dev: false
 
   /vue-eslint-parser/9.0.3_eslint@8.24.0:
     resolution: {integrity: sha512-yL+ZDb+9T0ELG4VIFo/2anAOz8SvBdlqEnQnvJ3M7Scq56DvtjY0VY88bByRZB0D4J0u8olBcfrXTVONXsh4og==}
@@ -6328,6 +6330,7 @@ packages:
       '@vue/runtime-dom': 3.2.40
       '@vue/server-renderer': 3.2.40_vue@3.2.40
       '@vue/shared': 3.2.40
+    dev: false
 
   /webidl-conversions/3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}

--- a/src/components/IconDetail.vue
+++ b/src/components/IconDetail.vue
@@ -1,5 +1,4 @@
 <script setup lang='ts'>
-import copyText from 'copy-text-to-clipboard'
 import { getIconSnippet, toComponentName } from '../utils/icons'
 import { collections } from '../data'
 import { activeMode, copyPreviewColor, getTransformedId, inBag, preferredCase, previewColor, showCaseSelect, showHelp, toggleBag } from '../store'
@@ -41,12 +40,24 @@ onKeyStroke('ArrowRight', (e) => {
   e.preventDefault()
 })
 
+async function copyText(text?: string) {
+  if (text) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return true
+    }
+    catch (err) {
+    }
+  }
+  return false
+}
+
 const copy = async (type: string) => {
   const text = await getIconSnippet(props.icon, type, true, color.value)
   if (!text)
     return
 
-  emit('copy', copyText(text))
+  emit('copy', await copyText(text))
 }
 
 const download = async (type: string) => {

--- a/src/components/IconSet.vue
+++ b/src/components/IconSet.vue
@@ -1,5 +1,4 @@
 <script setup lang='ts'>
-import copyText from 'copy-text-to-clipboard'
 import { useRoute, useRouter } from 'vue-router'
 import { activeMode, bags, getSearchResults, iconSize, isCurrentCollectionLoading, listType, showHelp, toggleBag } from '../store'
 import { isLocalMode } from '../env'
@@ -39,13 +38,25 @@ function toggleCategory(cat: string) {
     category.value = cat
 }
 
+async function copyText(text?: string) {
+  if (text) {
+    try {
+      await navigator.clipboard.writeText(text)
+      return true
+    }
+    catch (err) {
+    }
+  }
+  return false
+}
+
 async function onSelect(icon: string) {
   switch (activeMode.value) {
     case 'select':
       toggleBag(icon)
       break
     case 'copy':
-      onCopy(copyText(await getIconSnippet(icon, 'id', true) || icon))
+      onCopy(await copyText(await getIconSnippet(icon, 'id', true) || icon))
       break
     default:
       current = icon


### PR DESCRIPTION
### Description

Switches to modern Clipboard API to copy code samples to clipboard. Fixes copy to clipboard not working in Safari.

### Linked Issues

https://github.com/antfu/icones/issues/98

### Additional context

Clipboard API works in all modern browsers, does not require third party dependencies.
