### PR TITLE
fix: categroy layout overflow

### DIFF
--- a/src/components/IconSet.vue
+++ b/src/components/IconSet.vue
@@ -181,13 +181,13 @@ onKeyStroke('Escape', () => {
         </div>
 
         <!-- Categories -->
-        <div class="py-2 px-7 overflow-x-overlay flex flex-no-wrap select-none">
+        <div class="py-3 mx-8 overflow-x-overlay flex flex-nowrap gap-2 select-none">
           <template v-if="collection.categories">
             <div
               v-for="c of Object.keys(collection.categories)"
               :key="c"
               class="
-                whitespace-nowrap text-sm inline-block px-2 border border-gray-200 rounded-full m-1 hover:bg-gray-50 cursor-pointer
+                whitespace-nowrap text-sm inline-block px-2 border border-gray-200 rounded-full hover:bg-gray-50 cursor-pointer
                 dark:border-dark-200 dark:hover:bg-dark-200
               "
               :class="c === category ? 'text-primary border-primary dark:border-primary' : 'opacity-75'"


### PR DESCRIPTION

### Description

Fix `categroy` layout overflow
<img width="284" alt="image" src="https://user-images.githubusercontent.com/42139754/202464049-100c264e-6ab4-4906-b000-e7d87c36196e.png">


### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
