### PR TITLE
fix: include xmlns attribute in SVGs

### DIFF
--- a/src/utils/icons.ts
+++ b/src/utils/icons.ts
@@ -12,7 +12,8 @@ export async function getSvgLocal(icon: string, size = '1em', color = 'currentCo
   const built = buildIcon(data, { height: size })
   if (!built)
     return
-  return `<svg ${Object.entries(built.attributes).map(([k, v]) => `${k}="${v}"`).join(' ')}>${built.body}</svg>`.replace('currentColor', color)
+  const xlink = built.body.includes('xlink:') ? ' xmlns:xlink="http://www.w3.org/1999/xlink"' : ''
+  return `<svg xmlns="http://www.w3.org/2000/svg"${xlink} ${Object.entries(built.attributes).map(([k, v]) => `${k}="${v}"`).join(' ')}>${built.body}</svg>`.replace('currentColor', color)
 }
 
 export async function getSvg(icon: string, size = '1em', color = 'currentColor') {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Adds the `xmlns="http://www.w3.org/2000/svg"` attribute to locally generated SVGs, to have them properly rendered by some browsers, like firefox.
It also adds the `xmlns:xlink="http://www.w3.org/1999/xlink"` attribute if the SVG uses xlink in the body, like the iconify api does.

### Linked Issues

#103 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

After calling [`iconToSVG` ](https://github.com/iconify/api/blob/e045c74d0968e8e62239f6475d5241505c2b0ebd/src/http/responses/svg.ts#L53) (which is the same thing as `buildIcon`) the iconify api calls [`iconToHTML`](https://github.com/iconify/iconify/blob/main/packages/utils/src/svg/html.ts), which also adds the two missing attributes.
