### PR TITLE
compact component setting

### DIFF
--- a/src/components/WithNavbar.vue
+++ b/src/components/WithNavbar.vue
@@ -1,7 +1,11 @@
+<script setup lang="ts">
+const route = useRoute()
+</script>
+
 <template>
   <div class="flex h-screen flex-col overflow-hidden">
     <Navbar />
-    <div class="flex-auto overflow-overlay flex flex-col">
+    <div class="flex-auto flex flex-col" :class="route.path !== '/settings' ? 'overflow-overlay' : null">
       <slot />
     </div>
   </div>

--- a/src/pages/settings.vue
+++ b/src/pages/settings.vue
@@ -12,7 +12,7 @@ const categorizedCollections = computed(() => categories.map(category => ({
 
 <template>
   <WithNavbar>
-    <div p4>
+    <div p4 h-screen grid pb-20>
       <!-- <h1 text-xl>
         Features
       </h1>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
![WhatsApp Image 2023-03-22 at 01 10 15](https://user-images.githubusercontent.com/24811167/226807678-7eccb80d-d5fd-4d0f-a7aa-bc966c86e7ce.jpeg)

PR to adjust the overflow that the settings page suffers, with no visualization of the bottom bar.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
