### PR TITLE
feat: open caches and add fallback on sw interception

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ const router = createRouter({
 if (!isElectron && PWA) {
   // disable local storage cache when there is PWA:
   // we need to keep local storage when running dev server without PWA
+  // to avoid call iconify server api
   disableCache('all')
   router.isReady().then(async () => {
     const { registerSW } = await import('virtual:pwa-register')

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,5 +1,5 @@
 import { cleanupOutdatedCaches, createHandlerBoundToURL, precacheAndRoute } from 'workbox-precaching'
-import { clientsClaim } from 'workbox-core'
+import { cacheNames, clientsClaim } from 'workbox-core'
 import { NavigationRoute, registerRoute } from 'workbox-routing'
 import { getIcons } from '@iconify/utils'
 
@@ -19,23 +19,31 @@ registerRoute(new NavigationRoute(
 self.skipWaiting()
 clientsClaim()
 
+function openCaches(e: FetchEvent) {
+  e.waitUntil(caches.open(cacheNames.precache))
+  return Promise.resolve()
+}
+
 self.addEventListener('fetch', (e) => {
   const url = e.request.url
   const match = url.match(/^https:\/\/(api\.iconify\.design|api\.simplesvg\.com|api\.unisvg\.com)\/(.*)\.json\?icons=(.*)?/)
   if (match) {
     e.respondWith(
-      fetch(`/collections/${match[2]}-raw.json`)
-        .then((response) => {
-          return response.json()
-        }).then((collection) => {
-          return new Response(JSON.stringify(getIcons(
-            collection,
-            match[3].replaceAll('%2C', ',').split(','),
-          )), {
-            headers: {
-              'Content-Type': 'application/json',
-            },
-          })
+      openCaches(e)
+        .then(() => {
+          return fetch(`/collections/${match[2]}-raw.json`)
+            .then(response => response.json())
+            .then((collection) => {
+              return new Response(JSON.stringify(getIcons(
+                collection,
+                match[3].replaceAll('%2C', ',').split(','),
+              )), {
+                headers: {
+                  'Content-Type': 'application/json',
+                },
+              })
+            })
+            .catch(() => fetch(e.request))
         }),
     )
   }


### PR DESCRIPTION
I guess we can do 2 more optimizations on icones website with PWA:
- remove internal cache (if any): it seems we're caching visited collections in memory?
- remove split requests: when requesting a collection, there are a few requests, we can use just one