### PR TITLE
fix: use origin icon name to load icon data, close #160

### DIFF
--- a/src/components/Bag.vue
+++ b/src/components/Bag.vue
@@ -27,7 +27,7 @@ async function packIconFont() {
 
 async function PackSvgs(type: PackType = 'svg') {
   await PackZip(
-    bags.value.map(i => i.replace(':', '-')),
+    bags.value,
     'icones-bags',
     type,
   )

--- a/src/utils/pack.ts
+++ b/src/utils/pack.ts
@@ -81,6 +81,10 @@ export async function PackJsonZip(icons: string[], name: string) {
 
 export type PackType = 'svg' | 'tsx' | 'jsx' | 'vue' | 'json'
 
+function normalizeZipFleName(svgName: string): string {
+  return svgName.replace(':', '-')
+}
+
 export async function PackZip(
   icons: string[],
   name: string,
@@ -119,7 +123,7 @@ export async function PackZip(
   }
   else {
     for (const { name, svg } of data)
-      action(name, svg)
+      action(normalizeZipFleName(name), svg)
   }
   const blob = await zip.generateAsync({ type: 'blob' })
   Download(blob, `${name}-${type}.zip`)


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->
### Description
close #160 

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues
#160 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
This pr will change inner file name of zip file when the type of download is SVG or JSON