### PR TITLE
fix:  deleting overflow-y-overlay will cause problems, loadmore can't scroll

### DIFF
--- a/src/components/IconSet.vue
+++ b/src/components/IconSet.vue
@@ -150,7 +150,7 @@ useEventListener(categoriesContainer, 'wheel', (e: WheelEvent) => {
   <WithNavbar>
     <div class="flex flex-auto h-full overflow-hidden ">
       <Drawer class="h-full overflow-y-overlay flex-none hidden md:block" style="width:220px" />
-      <div v-if="collection" class="py-5 h-full flex-auto relative">
+      <div v-if="collection" class="py-5 overflow-y-overlay h-full flex-auto relative">
         <!-- Loading -->
         <div
           class="absolute top-0 left-0 right-0 bottom-0 bg-white bg-opacity-75 content-center transition-opacity duration-100 z-50 dark:bg-dark-100"


### PR DESCRIPTION
deleting overflow-y-overlay will cause problems, loadmore can't scroll

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
