### PR TITLE
fix: resolve scrolling and load-more issue in IconSetView when overflowed

### DIFF
--- a/src/components/IconSet.vue
+++ b/src/components/IconSet.vue
@@ -150,7 +150,7 @@ useEventListener(categoriesContainer, 'wheel', (e: WheelEvent) => {
   <WithNavbar>
     <div class="flex flex-auto h-full overflow-hidden ">
       <Drawer class="h-full overflow-y-overlay flex-none hidden md:block" style="width:220px" />
-      <div v-if="collection" class="py-5 h-full flex-auto relative">
+      <div v-if="collection" class="py-5 h-full flex-auto relative flex flex-col">
         <!-- Loading -->
         <div
           class="absolute top-0 left-0 right-0 bottom-0 bg-white bg-opacity-75 content-center transition-opacity duration-100 z-50 dark:bg-dark-100"
@@ -250,7 +250,8 @@ useEventListener(categoriesContainer, 'wheel', (e: WheelEvent) => {
         </div>
 
         <!-- Icons -->
-        <div class="px-4 pt-2 pb-4 text-center">
+        <!-- <div class="px-4 pt-2 pb-4 text-center overflow-hidden overflow-y-auto h-[calc(100%-18rem)]"> -->
+        <div class="px-4 pt-2 pb-4 text-center flex-grow flex-shrink overflow-hide overflow-y-auto min-h-0 [&>div]:overflow-hidden">
           <Icons
             :icons="icons.slice(0, max)"
             :selected="bags"

--- a/src/components/IconSet.vue
+++ b/src/components/IconSet.vue
@@ -250,7 +250,7 @@ useEventListener(categoriesContainer, 'wheel', (e: WheelEvent) => {
         </div>
 
         <!-- Icons -->
-        <!-- <div class="px-4 pt-2 pb-4 text-center overflow-hidden overflow-y-auto h-[calc(100%-18rem)]"> -->
+
         <div class="px-4 pt-2 pb-4 text-center flex-grow flex-shrink overflow-hide overflow-y-auto min-h-0 [&>div]:overflow-hidden">
           <Icons
             :icons="icons.slice(0, max)"


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

In this Pull Request (PR), I've addressed a usability issue impacting the IconSetView within our application.

The primary change is:

**IconSetView Overflow Fix**: I've fixed an issue where users couldn't scroll through or load more icons in `IconSet` when it was overflowed. With this fix, users can now seamlessly browse and load more icons, even when the IconSetView is overflowing, thus improving the overall usability of our application.
As always, I appreciate your time in reviewing this fix and look forward to any feedback or suggestions for further improvements.


### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
