### PR TITLE
 fix: export correct svelte component, close #143

### DIFF
--- a/src/utils/icons.ts
+++ b/src/utils/icons.ts
@@ -119,7 +119,7 @@ export function ${name}(props: JSX.IntrinsicElements['svg'], key: string) {
 }
 
 export function SvgToSvelte(svg: string) {
-  return ClearSvg(svg)
+  return `${svg.replace(/<svg (.*?)>/, '<svg $1 {...$$$props}>')}`
 }
 
 export async function getIconSnippet(icon: string, type: string, snippet = true, color = 'currentColor'): Promise<string | undefined> {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

Exports pure svg output for svelte component with props support  instead of jsx

fixes #143 

Here are some examples of the issue with previous and fixed implementation:

[Svelte REPL example](https://svelte.dev/repl/b4349c6a987f41198c489a380deb51be?version=4.1.1) 

### Linked Issues

#143 

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
