### PR TITLE
chore: tweak renovate.json for Enhanced @iconify/json Updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,8 @@
       "matchPackagePatterns": ["^@iconify/json"],
       "extends": ["schedule:daily"],
       "minimumReleaseAge": "1 day",
-      "automerge": true
+      "automerge": true,
+      "matchDatasources": ["npm"]
     },
     {
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
The current Renovate configuration encounters an issue when updating the "@iconify/json" package. Despite the availability of a release timestamp for "@iconify/json," Renovate does not utilize this timestamp by default.

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
By introducing the "matchDatasources" setting with the value ["npm"] in the renovate.json file, we instruct Renovate to utilize the NPM registry datasource. This enhancement empowers Renovate to access the release timestamp for "@iconify/json" in the NPM registry, allowing updates to be triggered promptly, even if the package is newer than one day old.

### Linked Issues
None

### Additional context

None