### PR TITLE
fix: correct spelling for ph variants

### DIFF
--- a/src/data/variant-category.ts
+++ b/src/data/variant-category.ts
@@ -1,7 +1,7 @@
 export const variantCategories: Record<string, [string, string | RegExp][]> = {
   'ph': [
     ['Bold', '-bold'],
-    ['Duetone', '-duotone'],
+    ['Duotone', '-duotone'],
     ['Fill', '-fill'],
     ['Light', '-light'],
     ['Thin', '-thin'],


### PR DESCRIPTION
### Description

Just changed `Duetone` to `Duotone` in phosphor icon variants 👍 


