### PR TITLE
fix: do not convert attributes starting with stroke

### DIFF
--- a/src/utils/htmlToJsx.ts
+++ b/src/utils/htmlToJsx.ts
@@ -15,7 +15,7 @@ function transformToReactJSX(jsx: string) {
 export function HtmlToJSX(html: string, reactJSX = false) {
   const jsx = html.replace(/([\w-]+)=/g, (i) => {
     const words = i.split('-')
-    if (words.length === 1)
+    if (words.length === 1 || words[0] === 'stroke')
       return i
     return words
       .map((i, idx) =>


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
For example, if I copy the `line-md:uploading-loop` icon to a vue-ts component, attributes such as `stroke-dasharray` will be converted, causing related attributes to become invalid.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
