### PR TITLE
ci: enable Automerge for @iconify/json in Renovate Configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,7 +17,8 @@
       "description": "Create non-major @iconify/json updates daily",
       "matchUpdateTypes": ["minor", "patch"],
       "matchPackagePatterns": ["^@iconify/json"],
-      "extends": ["schedule:daily"]
+      "extends": ["schedule:daily"],
+      "automerge": true
     },
     {
       "description": "Suppress major updates using Dependency Dashboard",


### PR DESCRIPTION
Modify the Renovate configuration to enable "automerge" for daily non-major updates of the @iconify/json package.

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This pull request enhances the existing Renovate configuration to incorporate automerge functionality for daily non-major updates of the @iconify/json package.
### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
