### PR TITLE
feat: support unocss with colon format

### DIFF
--- a/src/utils/case.ts
+++ b/src/utils/case.ts
@@ -29,6 +29,9 @@ export const idCases = {
   componentKebab(id: string) {
     return `<${id.replace(/:/g, '-')}/>`
   },
+  unocssColon(id: string) {
+    return `i-${id}`
+  },
   unocss(id: string) {
     return `i-${id.replace(/:/g, '-')}`
   },


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Adds an additional format for UnoCSS users that prefer the colon over the dash. Ordered before the dash version to keep consistency with the non-i-prefixed formats above.

![image](https://github.com/antfu/icones/assets/47396035/0946cc31-2f28-4980-93af-53fce85f1790)

### Linked Issues

none

### Additional context

Similar to #158 and #161 
