### PR TITLE
chore: fix the build script

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "dev": "vite ../ --port 3333 --mode electron",
     "copy": "cp -r ../dist ./",
-    "build": "vite build ../ --mode electron && yarn copy && electron-builder"
+    "build": "vite build ../ --mode electron && pnpm copy && electron-builder"
   },
   "devDependencies": {
     "electron": "24.8.2",


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fixed the build script where used `yarn copy` instead of the `pnpm copy`. The original script will cause conflicts with the `"packageManager": "pnpm@8.7.1"` wrote in the package.json.

