### PR TITLE
fix: chinese path error 'no such file or directory'

### DIFF
--- a/scripts/prepare.ts
+++ b/scripts/prepare.ts
@@ -1,7 +1,8 @@
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import fs from 'fs-extra'
 
-const __dirname = path.dirname(new URL(import.meta.url).pathname)
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const out = path.resolve(__dirname, '../public')
 
 function ObjectPick(source: Record<string, any>, keys: string[]) {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

When the parent directory uses a Chinese path, it will report an error: 'no such file or directory'.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
