### PR TITLE
chore: exclude `ttf2woff2` build when installing dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "neverBuiltDependencies": [
       "electron",
       "electron-builder",
+      "ttf2woff2",
       "vite-plugin-electron",
       "vite-plugin-electron-renderer",
       "vite-plugin-esmodule"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 neverBuiltDependencies:
   - electron
   - electron-builder
+  - ttf2woff2
   - vite-plugin-electron
   - vite-plugin-electron-renderer
   - vite-plugin-esmodule
@@ -7531,7 +7532,6 @@ packages:
     resolution: {integrity: sha512-5/Web6B0lF/STNAQ0d5vAlRRquuWsNj8wOmKQ9ql9Bsgbx8MsLnNzaBG9vBcSE4s4Ry1QOr/MyUrDUIVgVPEfw==}
     engines: {node: '>= 4.0.0'}
     hasBin: true
-    requiresBuild: true
     dependencies:
       bindings: 1.5.0
       bufferstreams: 2.0.1


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
When installing dependencies on my Windows laptop `ttf2woff2` is built and it is failing (no idea if required):
<details>
<summary>error running pnpm install --frozen-lockfile</summary>

```shell
node_modules/.pnpm/ttf2woff2@3.0.0/node_modules/ttf2woff2: Running install script...
node:events:492
      throw er; // Unhandled 'error' event
      ^

Error: ENOENT: no such file or directory, open 'D:\work\antfu\icones\D:\work\antfu\icones\node_modules\.pnpm\ttf2woff2@3.0.0\node_modules\ttf2woff2\builderror.lo
g'
Emitted 'error' event on WriteStream instance at:
    at WriteStream.onerror (node:internal/streams/readable:1004:14)
    at WriteStream.emit (node:events:514:28)
    at emitErrorNT (node:internal/streams/destroy:151:8)
    at emitErrorCloseNT (node:internal/streams/destroy:116:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  errno: -4058,
  code: 'ENOENT',
  syscall: 'open',
  path: 'D:\\work\\antfu\\icones\\D:\\work\\antfu\\icones\\node_modules\\.pnpm\\ttf2woff2@3.0.0\\node_modules\\ttf2woff2\\builderror.log'
}

Node.js v20.10.0
```
</details>

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
