### PR TITLE
chore: fix install on Windows and ttf2woff2

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
 packages:
   - electron
-onlyBuiltDependencies:
+neverBuiltDependencies:
   - ttf2woff2


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Your last commit at #364 moving the `pnpm.neverBuiltDependencies` to the workspace yaml file, but using `onlyBuiltDependencies`  instead `neverBuiltDependencies`, I cannot install dependencies, check the screenshot (tried with Node 20.10 and 22.13 LTS).

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
![image](https://github.com/user-attachments/assets/21814749-0704-49e1-891f-e2078cae8560)

