### PR TITLE
fix: set width on icon container to avoid content shift

### DIFF
--- a/src/components/Icon.vue
+++ b/src/components/Icon.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { loadIcon } from 'iconify-icon'
 import { LRUCache } from 'lru-cache'
 
 const cache = new LRUCache<string, HTMLElement>({
@@ -29,8 +30,6 @@ function unmountIcon(name: string, icon: HTMLElement) {
 </script>
 
 <script setup lang="ts">
-import { loadIcon } from 'iconify-icon'
-
 const props = defineProps({
   icon: {
     type: String,


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

Fixes content shift by setting fixed width on icon container, which matches icon's width/height ratio.

### Linked Issues

fix https://github.com/antfu-collective/icones/issues/368

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
