### PR TITLE
fix: make bag scrollable when overflowing

### DIFF
--- a/src/components/Bag.vue
+++ b/src/components/Bag.vue
@@ -66,7 +66,7 @@ async function PackSvgs(type: PackType = 'svg') {
     </div>
 
     <template v-if="bags.length">
-      <div class="flex-auto overflow-y-overflow py-3 px-1">
+      <div class="flex-auto overflow-y-auto py-3 px-1">
         <Icons :icons="bags" @select="(e: any) => $emit('select', e)" />
       </div>
 


### PR DESCRIPTION
### 🔗 Linked issue

Closes #390

### 🧐 Context

When too many icons were added to the bag, the container became non-scrollable, causing the action buttons at the bottom (such as export/download options) to become inaccessible.

This happened because the container was using an invalid overflow utility class.

### 📖 Description

- Replaced the invalid `overflow-y-overflow` class with `overflow-y-auto`
- Restored vertical scrolling for overflowing icon lists
- Ensured export/download actions remain accessible when the bag contains many icons

This fix only affects the scrolling behaviour of the bag container and does not change existing functionality.