### PR TITLE
fix: preserve kebab-case SVG attributes for Qwik components

### DIFF
--- a/src/utils/svg/helpers.ts
+++ b/src/utils/svg/helpers.ts
@@ -17,7 +17,7 @@ export function toComponentName(icon: string) {
   return icon.split(/[:\-_]/).filter(Boolean).map(s => s[0].toUpperCase() + s.slice(1).toLowerCase()).join('')
 }
 
-export function ClearSvg(svgCode: string, reactJSX?: boolean) {
+export function ClearSvg(svgCode: string, reactJSX?: boolean, skipJSXTransform?: boolean) {
   const result = transformSync(parse(svgCode).children[0] as Node, [
     (node: Node): Node => {
       if (node.name !== 'svg')
@@ -37,6 +37,9 @@ export function ClearSvg(svgCode: string, reactJSX?: boolean) {
       return node
     },
   ])
+
+  if (skipJSXTransform)
+    return result
 
   return HtmlToJSX(result, reactJSX)
 }
@@ -77,7 +80,7 @@ export function SvgToQwik(svg: string, name: string, snippet: boolean) {
   let code = `
 export function ${name}(props: QwikIntrinsicElements['svg'], key: string) {
   return (
-    ${ClearSvg(svg, false).replace(/<svg (.*?)>/, '<svg $1 {...props} key={key}>')}
+    ${ClearSvg(svg, false, true).replace(/<svg (.*?)>/, '<svg $1 {...props} key={key}>')}
   )
 }`
 


### PR DESCRIPTION
Qwik JSX supports native HTML/SVG attribute names unlike React. Skip the camelCase conversion in HtmlToJSX when generating Qwik snippets.

Closes #320

### 🔗 Linked issue

Resolves #320

### ✅ Context

Qwik works with unmodified SVG — it uses native attribute names like `stop-color`, `fill-opacity`, `clip-path` directly in JSX. Unlike React, it does not require camelCase conversion. Currently, `SvgToQwik` calls `ClearSvg(svg, false)`, which still passes the output through `HtmlToJSX()` and converts kebab-case attributes to camelCase (e.g. `stop-color` → `stopColor`). This is incorrect for Qwik.

### 🍔 Description

Added a `skipJSXTransform` parameter to `ClearSvg()`. When `true`, the function returns the filtered SVG string directly without calling `HtmlToJSX()`, preserving native kebab-case attribute names.

Changed `SvgToQwik` to call `ClearSvg(svg, false, true)` so that Qwik-generated snippets keep original SVG attribute names:

- `stop-color` stays `stop-color` (not `stopColor`)
- `fill-opacity` stays `fill-opacity` (not `fillOpacity`)
- `clip-path` stays `clip-path` (not `clipPath`)

Only `src/utils/svg/helpers.ts` is modified. No impact on other frameworks.