### PR TITLE
feat: add search syntax documentation to help page

### DIFF
--- a/src/components/HelpPage.vue
+++ b/src/components/HelpPage.vue
@@ -39,6 +39,97 @@
     <p class="mt-2">
       Check out <a href="https://antfu.me/posts/journey-with-icons-continues" target="_blank">this blog post</a> for the story behind.
     </p>
+
+    <h2 class="bold text-lg mt-5 mb-1">
+      Search Syntax
+    </h2>
+    <p>
+      The search is powered by <a href="https://github.com/junegunn/fzf#search-syntax" target="_blank">fzf</a>.
+      By default, it uses fuzzy matching. You can use the following syntax for more precise results:
+    </p>
+    <table class="mt-2 w-full text-sm">
+      <thead>
+        <tr class="text-left">
+          <th class="py-1 pr-3">
+            Token
+          </th>
+          <th class="py-1 pr-3">
+            Match type
+          </th>
+          <th class="py-1">
+            Example
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="py-1 pr-3">
+            <code>'word</code>
+          </td>
+          <td class="py-1 pr-3">
+            Exact match
+          </td>
+          <td class="py-1">
+            <code>'heart</code>
+          </td>
+        </tr>
+        <tr>
+          <td class="py-1 pr-3">
+            <code>^word</code>
+          </td>
+          <td class="py-1 pr-3">
+            Prefix match
+          </td>
+          <td class="py-1">
+            <code>^arrow</code>
+          </td>
+        </tr>
+        <tr>
+          <td class="py-1 pr-3">
+            <code>word$</code>
+          </td>
+          <td class="py-1 pr-3">
+            Suffix match
+          </td>
+          <td class="py-1">
+            <code>left$</code>
+          </td>
+        </tr>
+        <tr>
+          <td class="py-1 pr-3">
+            <code>!word</code>
+          </td>
+          <td class="py-1 pr-3">
+            Negation
+          </td>
+          <td class="py-1">
+            <code>!outline</code>
+          </td>
+        </tr>
+        <tr>
+          <td class="py-1 pr-3">
+            <code>a | b</code>
+          </td>
+          <td class="py-1 pr-3">
+            OR
+          </td>
+          <td class="py-1">
+            <code>'heart | 'star</code>
+          </td>
+        </tr>
+        <tr>
+          <td class="py-1 pr-3">
+            <code>a b</code>
+          </td>
+          <td class="py-1 pr-3">
+            AND (multiple terms)
+          </td>
+          <td class="py-1">
+            <code>'arrow 'left</code>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </template>
 
@@ -48,5 +139,11 @@
 }
 .help-page a {
   @apply text-primary opacity-75 hover:opacity-100;
+}
+.help-page table {
+  @apply text-black/60 dark:text-white/60;
+}
+.help-page code {
+  @apply px-1.5 py-0.5 rounded bg-gray/10 text-black/80 dark:text-white/80 font-mono text-xs;
 }
 </style>


### PR DESCRIPTION
Document the fzf-powered search syntax (exact match, prefix, suffix, negation, OR) in the help modal so users can discover advanced search.

Closes #131

### 🔗 Linked issue

Resolves #131

### ✅ Context

PR #85 introduced fzf-powered search but the extended match syntax was never documented. Users don't know they can use tokens like `'word` for exact match, leading to poor search results especially across large collections.

### 🍔 Description

Added a "Search Syntax" section to `HelpPage.vue` with a table listing all supported fzf tokens:

| Token | Match type |
|-------|-----------|
| `'word` | Exact match |
| `^word` | Prefix match |
| `word$` | Suffix match |
| `!word` | Negation |
| `a \| b` | OR |
| `a b` | AND |

Also added basic styles for `<table>` and `<code>` in the help page.

Documentation-only change, no logic changes.